### PR TITLE
[VEN-581]: Use deposit validation result to ensure the transaction detail are correct

### DIFF
--- a/src/api/test/helpers/instance.js
+++ b/src/api/test/helpers/instance.js
@@ -1,8 +1,7 @@
 /**
  * Creats a client instance for testing
  **/
-const HDWalletProvider = require('@truffle/hdwallet-provider')
-const Web3 = require('web3')
+const getWeb3 = require('../../../../examples/helpers/getWeb3')
 
 const DVF = require('../../../dvf')
 
@@ -10,14 +9,7 @@ module.exports = async () => {
   const rpcUrl = process.env.RPC_URL
   const privateKey = process.env.PRIVATE_ETH_KEY
 
-  const provider = new HDWalletProvider({
-    privateKeys: [privateKey],
-    providerOrUrl: rpcUrl
-  })
-
-  const web3 = new Web3(provider)
-
-  provider.engine.stop()
+  const { web3 } = getWeb3(privateKey, rpcUrl)
 
   const gasStationApiKey = process.env.ETH_GAS_STATION_KEY || ''
 


### PR DESCRIPTION
Do not proceed with L1 tx if starkKey or vaultId does not match backend response

can also directly use `vaultId` and `starkKey` from the result of `deposit-validation`